### PR TITLE
fix(wx): preserve page HMR on Windows

### DIFF
--- a/.agents/skills/test-published-packages/scripts/test-published-packages.ts
+++ b/.agents/skills/test-published-packages/scripts/test-published-packages.ts
@@ -3,6 +3,7 @@
 import { type ChildProcess, spawn, spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { closeSync, copyFileSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
@@ -12,6 +13,11 @@ interface CommandResult {
     stdout: string
     stderr: string
     error: Error | undefined
+}
+
+interface CommandInvocation {
+    executable: string
+    args: readonly string[]
 }
 
 type ReleaseTag = 'beta' | 'latest'
@@ -38,14 +44,15 @@ interface ProjectPaths {
 
 const skillDirectory = resolve(fileURLToPath(new URL('.', import.meta.url)), '..')
 const repositoryRoot = resolve(skillDirectory, '../../..')
-const temporaryRoot = '/tmp/vpt-published-packages-test'
+const temporaryDirectory = tmpdir()
+const temporaryRoot = resolve(temporaryDirectory, 'vpt-published-packages-test')
 const projectPaths: ProjectPaths = {
     root: temporaryRoot,
     output: resolve(temporaryRoot, 'dist/wx'),
     source: resolve(temporaryRoot, 'src/pages/home/index.tsx'),
     counterSource: resolve(temporaryRoot, 'src/components/counter/counter.tsx'),
     backup: resolve(temporaryRoot, '.hmr-test-index.tsx.backup'),
-    viteLog: '/tmp/vpt-published-packages-test-vite.log'
+    viteLog: resolve(temporaryDirectory, 'vpt-published-packages-test-vite.log')
 }
 const appIdSource = resolve(repositoryRoot, 'packages/loan-genius/.env.local')
 const miniProgramSkill = resolve(repositoryRoot, '.agents/skills/miniprogram-dev-skill')
@@ -61,8 +68,15 @@ function stage(message: string): void {
     console.log(`\n[published-packages] ${message}`)
 }
 
+function createCommandInvocation(command: string, args: readonly string[]): CommandInvocation {
+    return process.platform === 'win32'
+        ? { executable: 'cmd.exe', args: ['/d', '/s', '/c', command, ...args] }
+        : { executable: command, args: args }
+}
+
 function execute(command: string, args: readonly string[], cwd: string, timeoutMs: number | undefined): CommandResult {
-    const result = spawnSync(command, args, {
+    const invocation = createCommandInvocation(command, args)
+    const result = spawnSync(invocation.executable, invocation.args, {
         cwd,
         encoding: 'utf8',
         maxBuffer: 20 * 1024 * 1024,
@@ -232,7 +246,7 @@ function createFreshProject(identity: PackageIdentity): void {
     requireCommand(
         'npm',
         ['create', `vite-taro@${identity.releaseTag}`, 'vpt-published-packages-test'],
-        '/tmp',
+        temporaryDirectory,
         undefined
     )
     const installOutput = requireCommand('npm', ['install'], projectPaths.root, undefined)
@@ -330,8 +344,8 @@ function validateStaticBuild(): void {
 }
 
 function readSkillVersion(): string {
-    const yaml = readFileSync(resolve(miniProgramSkill, 'skill.yaml'), 'utf8')
-    const match = /^version:\s*(\S+)$/m.exec(yaml)
+    const skill = readFileSync(resolve(miniProgramSkill, 'SKILL.md'), 'utf8')
+    const match = /^version:\s*(\S+)$/m.exec(skill)
     if (match === null) {
         throw new Error('Unable to read miniprogram-dev-skill version')
     }
@@ -340,10 +354,14 @@ function readSkillVersion(): string {
 
 function validateDevToolsStatus(): void {
     const result = requireRecord(
-        callWechatide('check_devtools_status', ['--skill-version', readSkillVersion()], true),
+        callWechatide('check_wechatide_status', ['--skill-version', readSkillVersion()], true),
         'DevTools status'
     )
-    requireString(result.openid, 'DevTools status openid')
+    const loginUser = requireRecord(result.loginUser, 'DevTools status login user')
+    requireString(loginUser.openid, 'DevTools status openid')
+    if (result.loginExpired !== false) {
+        throw new Error('WeChat DevTools login is expired')
+    }
 }
 
 function startDevServer(): ChildProcess {
@@ -351,9 +369,10 @@ function startDevServer(): ChildProcess {
     rmSync(projectPaths.viteLog, { force: true })
     mkdirSync(resolve(projectPaths.output, '..'), { recursive: true })
     const logDescriptor = openSync(projectPaths.viteLog, 'w')
-    const child = spawn('npm', ['run', 'dev:wx'], {
+    const invocation = createCommandInvocation('npm', ['run', 'dev:wx'])
+    const child = spawn(invocation.executable, invocation.args, {
         cwd: projectPaths.root,
-        detached: true,
+        detached: process.platform !== 'win32',
         stdio: ['ignore', logDescriptor, logDescriptor]
     })
     closeSync(logDescriptor)
@@ -394,7 +413,11 @@ function processGroupExists(pid: number): boolean {
 }
 
 async function stopDevServer(child: ChildProcess): Promise<void> {
-    if (child.pid === undefined) {
+    if (child.pid === undefined || child.exitCode !== null) {
+        return
+    }
+    if (process.platform === 'win32') {
+        requireCommand('taskkill', ['/pid', String(child.pid), '/t', '/f'], repositoryRoot, commandTimeoutMs)
         return
     }
     signalProcessGroup(child.pid, 'SIGTERM')
@@ -422,10 +445,10 @@ function currentRoute(): string | undefined {
         ['--project', projectPaths.output, '--action', 'currentPage'],
         false
     )
-    if (!isRecord(result)) {
+    if (!isRecord(result) || !isRecord(result.currentPage)) {
         return undefined
     }
-    return typeof result.route === 'string' ? result.route : undefined
+    return typeof result.currentPage.route === 'string' ? result.currentPage.route : undefined
 }
 
 function findCounterCount(value: unknown): number | undefined {

--- a/packages/loan-genius/scripts/hmr-cases.ts
+++ b/packages/loan-genius/scripts/hmr-cases.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { setTimeout as delay } from 'node:timers/promises'
-import { isRecord, type LoanHmrDevTools, waitFor } from './hmr-devtools.ts'
+import { type LoanHmrDevTools, waitFor } from './hmr-devtools.ts'
 import { type LoanHmrFixture, replaceOnce } from './hmr-fixture.ts'
 
 type HmrContext = Readonly<{
@@ -46,12 +46,28 @@ export async function runLoanHmrCases(context: HmrContext): Promise<void> {
     await context.devTools.element('#loan-submit', 'tap', undefined)
     await waitForElement(context, '#loan-result-header')
 
+    await runIsolatedPageFlow(context)
     await runCalculatorFlows(context)
     await runOverlayFlows(context)
     await runNavigationFlows(context)
     await runRecoveryFlow(context)
     await runNormalRemountFlow(context)
     assert.equal(await context.devTools.readConsoleErrors(), '')
+}
+
+async function runIsolatedPageFlow(context: HmrContext): Promise<void> {
+    const file = 'src/pages/calculator/index.tsx'
+    const original = await context.fixture.read(file)
+    try {
+        await context.fixture.write(file, replaceOnce(original, 'direct-page-baseline', 'direct-page-updated'))
+        await waitForElementText(context, '#loan-direct-page-probe', 'direct-page-updated')
+        await assertCalculatorState(context)
+    } finally {
+        await context.fixture.write(file, original)
+    }
+    await waitForElementText(context, '#loan-direct-page-probe', 'direct-page-baseline')
+    await assertCalculatorState(context)
+    console.log('[loan-hmr] 00-isolated-page-self-update passed')
 }
 
 async function runCalculatorFlows(context: HmrContext): Promise<void> {
@@ -409,8 +425,8 @@ async function runFlow(
 }
 
 async function assertWxSafeClasses(context: HmrContext, generation: string): Promise<void> {
-    const current = await context.devTools.readRuntime('currentPage')
-    if (!isRecord(current) || current.path !== calculatorRoute) {
+    const currentPage = await context.devTools.readCurrentPage()
+    if (currentPage.path !== calculatorRoute) {
         return
     }
 
@@ -425,10 +441,15 @@ async function assertCalculatorState(context: HmrContext): Promise<void> {
 }
 
 async function waitForMarker(context: HmrContext, markerFile: string, value: string): Promise<void> {
+    await waitForElementText(context, '#loan-hmr-marker', value)
+    assert.equal(await context.fixture.read(markerFile), `export const hmrMarker = '${value}'\n`)
+}
+
+async function waitForElementText(context: HmrContext, selector: string, value: string): Promise<void> {
     await waitFor(
         async () => {
             try {
-                return (await context.devTools.element('#loan-hmr-marker', 'text', undefined)) === value
+                return (await context.devTools.element(selector, 'text', undefined)) === value
             } catch {
                 return false
             }
@@ -436,23 +457,14 @@ async function waitForMarker(context: HmrContext, markerFile: string, value: str
         8_000,
         75
     )
-    assert.equal(await context.fixture.read(markerFile), `export const hmrMarker = '${value}'\n`)
 }
 
 async function waitForRoute(context: HmrContext, route: string): Promise<void> {
-    await waitFor(
-        async () => {
-            const current = await context.devTools.readRuntime('currentPage')
-            return isRecord(current) && current.path === route
-        },
-        8_000,
-        75
-    )
+    await waitFor(async () => (await context.devTools.readCurrentPage()).path === route, 8_000, 75)
 }
 
 async function assertRoute(context: HmrContext, route: string): Promise<void> {
-    const current = await context.devTools.readRuntime('currentPage')
-    assert.equal(isRecord(current) ? current.path : undefined, route)
+    assert.equal((await context.devTools.readCurrentPage()).path, route)
 }
 
 async function waitForElement(context: HmrContext, selector: string): Promise<void> {

--- a/packages/loan-genius/scripts/hmr-devtools.ts
+++ b/packages/loan-genius/scripts/hmr-devtools.ts
@@ -9,13 +9,16 @@ export type LoanHmrDevTools = Readonly<{
     navigate: (action: string, url: string | undefined) => Promise<void>
     openProject: () => Promise<void>
     readConsoleErrors: () => Promise<string>
-    readRuntime: (action: string) => Promise<unknown>
+    readCurrentPage: () => Promise<Record<string, unknown>>
 }>
 
 type ToolParameters = Readonly<Record<string, string>>
 
 const execFileAsync = promisify(execFile)
+const elementReadActions: readonly string[] = ['outerWxml', 'text', 'value', 'wxml']
 const commandTimeoutMilliseconds = 12_000
+const devToolsExecutable = process.platform === 'win32' ? 'cmd.exe' : 'wechatide'
+const devToolsArguments = process.platform === 'win32' ? ['/d', '/s', '/c', 'wechatide'] : []
 const devToolsClient = process.env.VPT_LOAN_HMR_DEVTOOLS_CLIENT ?? 'Pi'
 
 export function createLoanHmrDevTools(fixture: LoanHmrFixture): LoanHmrDevTools {
@@ -30,10 +33,13 @@ export function createLoanHmrDevTools(fixture: LoanHmrFixture): LoanHmrDevTools 
                     ? { selector: selector, action: action }
                     : { selector: selector, action: action, value: value }
             const result = await runTool('automation_element_action', parameters)
-            if (typeof result !== 'string') {
-                throw new Error(`Expected string result for ${selector}:${action}`)
+            if (elementReadActions.includes(action)) {
+                if (typeof result !== 'string') {
+                    throw new Error(`Expected string result for ${selector}:${action}`)
+                }
+                return result
             }
-            return result
+            return ''
         },
         navigate: async (action, url) => {
             const parameters: ToolParameters = url === undefined ? { action: action } : { action: action, url: url }
@@ -61,7 +67,13 @@ export function createLoanHmrDevTools(fixture: LoanHmrFixture): LoanHmrDevTools 
                 .filter((line) => line.length > 0 && isErrorConsoleEntry(line))
                 .join('\n')
         },
-        readRuntime: (action) => runTool('automation_runtime_info', { action: action })
+        readCurrentPage: async () => {
+            const result = await runTool('automation_runtime_info', { action: 'currentPage' })
+            if (!isRecord(result) || !isRecord(result.currentPage)) {
+                throw new Error('Expected current page result')
+            }
+            return result.currentPage
+        }
     }
 }
 
@@ -77,8 +89,8 @@ async function runToolWithTimeout(
 ): Promise<unknown> {
     const parameterArguments = Object.entries(parameters).flatMap(([name, value]) => [`--${name}`, value])
     const { stdout } = await execFileAsync(
-        'wechatide',
-        ['-c', devToolsClient, '-t', tool, '--project', fixture.outDir, ...parameterArguments],
+        devToolsExecutable,
+        [...devToolsArguments, '-c', devToolsClient, '-t', tool, '--project', fixture.outDir, ...parameterArguments],
         {
             cwd: fixture.repositoryRoot,
             env: process.env,
@@ -124,6 +136,6 @@ export async function waitFor(
     }
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null
 }

--- a/packages/loan-genius/scripts/hmr-fixture.ts
+++ b/packages/loan-genius/scripts/hmr-fixture.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { cp, type FileHandle, mkdir, open, readFile, rm, symlink, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
@@ -26,8 +27,8 @@ type FixtureTest = (fixture: LoanHmrFixture) => Promise<void>
 const scriptsRoot = path.dirname(fileURLToPath(import.meta.url))
 const packageRoot = path.dirname(scriptsRoot)
 const repositoryRoot = path.resolve(packageRoot, '../..')
-const fixtureRoot = '/tmp/vite-plugin-taro-loan-genius-hmr-v1'
-const fixtureLockPath = '/tmp/vite-plugin-taro-loan-genius-hmr.lock'
+const fixtureRoot = path.join(tmpdir(), 'vite-plugin-taro-loan-genius-hmr-v1')
+const fixtureLockPath = path.join(tmpdir(), 'vite-plugin-taro-loan-genius-hmr.lock')
 
 /** Runs one suite against the fixed trusted DevTools project without allowing concurrent source mutation. */
 export async function withLoanHmrFixture(test: FixtureTest): Promise<void> {
@@ -94,7 +95,11 @@ async function prepareFixture(): Promise<LoanHmrFixture> {
     if (existsSync(path.join(packageRoot, '.env.local'))) {
         await cp(path.join(packageRoot, '.env.local'), path.join(fixtureRoot, '.env.local'))
     }
-    await symlink(path.join(packageRoot, 'node_modules'), path.join(fixtureRoot, 'node_modules'), 'dir')
+    await symlink(
+        path.join(packageRoot, 'node_modules'),
+        path.join(fixtureRoot, 'node_modules'),
+        process.platform === 'win32' ? 'junction' : 'dir'
+    )
 
     const fixture = createFixture()
     await configureAutomatableRenderer(fixture)
@@ -106,7 +111,8 @@ function createFixture(): LoanHmrFixture {
     const write = (relativePath: string, source: string) => writeFile(path.join(fixtureRoot, relativePath), source)
     return {
         outDir: path.join(fixtureRoot, 'dist/wx'),
-        read: (relativePath) => readFile(path.join(fixtureRoot, relativePath), 'utf8'),
+        read: async (relativePath) =>
+            (await readFile(path.join(fixtureRoot, relativePath), 'utf8')).replaceAll('\r\n', '\n'),
         repositoryRoot: repositoryRoot,
         root: fixtureRoot,
         publishMarker: async (markerFile, value) => {
@@ -147,7 +153,7 @@ async function instrumentSources(fixture: LoanHmrFixture): Promise<void> {
             ],
             [
                 '            <NavigationBar backgroundColor={backgroundColor} color={navigationBarColor}>',
-                '            <Text id="loan-hmr-marker">{hmrMarker}</Text>\n            <NavigationBar backgroundColor={backgroundColor} color={navigationBarColor}>'
+                '            <Text id="loan-direct-page-probe">direct-page-baseline</Text>\n            <Text id="loan-hmr-marker">{hmrMarker}</Text>\n            <NavigationBar backgroundColor={backgroundColor} color={navigationBarColor}>'
             ],
             [
                 '                <Button\n                    className="flex p-2',
@@ -260,7 +266,7 @@ export function replaceOnce(source: string, oldText: string, newText: string): s
 export async function startLoanHmrServer(fixture: LoanHmrFixture): Promise<LoanHmrServer> {
     const logPath = path.join(fixture.root, 'vite.log')
     const logFile = await open(logPath, 'w')
-    const server = spawn(path.join(fixture.root, 'node_modules/.bin/vite'), [], {
+    const server = spawn(process.execPath, [path.join(fixture.root, 'node_modules/vite/bin/vite.js')], {
         cwd: fixture.root,
         env: { ...process.env, NODE_ENV: 'development', VITE_VPT_TARGET: 'wx' },
         stdio: ['ignore', logFile.fd, logFile.fd]

--- a/packages/loan-genius/scripts/run-hmr-tests.ts
+++ b/packages/loan-genius/scripts/run-hmr-tests.ts
@@ -13,9 +13,9 @@ await withLoanHmrFixture(async (fixture) => {
         try {
             // The first App service reload follows project compilation; interactions begin only after that runtime is stable.
             await delay(5_000)
-            console.log(`[loan-hmr] running 25 flows in ${fixture.root}`)
+            console.log(`[loan-hmr] running 26 flows in ${fixture.root}`)
             await runLoanHmrCases({ devTools: devTools, fixture: fixture })
-            console.log('[loan-hmr] all 25 complex flows passed')
+            console.log('[loan-hmr] all 26 complex flows passed')
         } catch (error) {
             console.error(
                 `[loan-hmr] Vite log before cleanup:\n${await readFile(path.join(fixture.root, 'vite.log'), 'utf8')}`

--- a/packages/vite-plugin-taro/src/node/plugins/h5/resolver/module-resolver.test.ts
+++ b/packages/vite-plugin-taro/src/node/plugins/h5/resolver/module-resolver.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import path from 'node:path'
 import test from 'node:test'
+import { normalizePath } from 'vite'
 import type { VptOptions } from '../../../../options.ts'
 import { appComponentId } from '../../client/constant.ts'
 import { h5AppPath } from '../constant.ts'
@@ -19,7 +20,10 @@ test('resolves the configured App component', () => {
     const resolver = createModuleResolver(options)
     const projectRoot = path.resolve('/project')
 
-    assert.equal(resolver.resolveId({ id: appComponentId, projectRoot }), path.resolve(projectRoot, 'src/app.tsx'))
+    assert.equal(
+        resolver.resolveId({ id: appComponentId, projectRoot }),
+        normalizePath(path.resolve(projectRoot, 'src/app.tsx'))
+    )
     assert.equal(resolver.resolveId({ id: 'react', projectRoot }), undefined)
 })
 

--- a/packages/vite-plugin-taro/src/node/plugins/wx/resolve/resolver.test.ts
+++ b/packages/vite-plugin-taro/src/node/plugins/wx/resolve/resolver.test.ts
@@ -71,19 +71,6 @@ test('resolves fixed and route-specific private IDs', () => {
     )
 })
 
-test('normalizes configured component IDs before they enter the module graph', () => {
-    const resolver = createResolver(options)
-    const projectRoot = 'C:\\projects\\my-app'
-    const pageCapsule = resolver.resolveId(pageCapsuleId, '/runtime/page.js?route=pages%2Fhome%2Findex', projectRoot)
-    const appComponent = resolver.resolveId(appComponentId, undefined, projectRoot)
-    const pageComponent = resolver.resolveId(pageComponentId, pageCapsule, projectRoot)
-
-    assert.ok(appComponent)
-    assert.ok(pageComponent)
-    assert.doesNotMatch(appComponent, /\\/)
-    assert.doesNotMatch(pageComponent, /\\/)
-})
-
 test('rejects Page-private imports without one configured route origin', () => {
     const resolver = createResolver(options)
     const projectRoot = path.resolve('/project')

--- a/packages/vite-plugin-taro/src/node/plugins/wx/resolve/resolver.test.ts
+++ b/packages/vite-plugin-taro/src/node/plugins/wx/resolve/resolver.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import path from 'node:path'
 import test from 'node:test'
+import { normalizePath } from 'vite'
 import type { VptOptions } from '../../../../options.ts'
 import { appComponentId } from '../../client/constant.ts'
 import {
@@ -57,14 +58,30 @@ test('resolves fixed and route-specific private IDs', () => {
         'pages/home/index-capsule': `${pageCapsulePath}?route=pages%2Fhome%2Findex`
     })
     assert.equal(resolver.resolveId(vitePreloadId, undefined, projectRoot), bootstrapPath)
-    assert.equal(resolver.resolveId(appComponentId, undefined, projectRoot), path.resolve(projectRoot, 'src/app.tsx'))
+    assert.equal(
+        resolver.resolveId(appComponentId, undefined, projectRoot),
+        normalizePath(path.resolve(projectRoot, 'src/app.tsx'))
+    )
 
     const pageCapsule = resolver.resolveId(pageCapsuleId, '/runtime/page.js?route=pages%2Fhome%2Findex', projectRoot)
     assert.equal(pageCapsule, `${pageCapsulePath}?route=pages%2Fhome%2Findex`)
     assert.equal(
         resolver.resolveId(pageComponentId, pageCapsule, projectRoot),
-        path.resolve(projectRoot, 'src/pages/home/index.tsx')
+        normalizePath(path.resolve(projectRoot, 'src/pages/home/index.tsx'))
     )
+})
+
+test('normalizes configured component IDs before they enter the module graph', () => {
+    const resolver = createResolver(options)
+    const projectRoot = 'C:\\projects\\my-app'
+    const pageCapsule = resolver.resolveId(pageCapsuleId, '/runtime/page.js?route=pages%2Fhome%2Findex', projectRoot)
+    const appComponent = resolver.resolveId(appComponentId, undefined, projectRoot)
+    const pageComponent = resolver.resolveId(pageComponentId, pageCapsule, projectRoot)
+
+    assert.ok(appComponent)
+    assert.ok(pageComponent)
+    assert.doesNotMatch(appComponent, /\\/)
+    assert.doesNotMatch(pageComponent, /\\/)
 })
 
 test('rejects Page-private imports without one configured route origin', () => {

--- a/packages/vite-plugin-taro/src/node/utils/modules.ts
+++ b/packages/vite-plugin-taro/src/node/utils/modules.ts
@@ -13,12 +13,12 @@ type PageComponentPathOptions = {
 
 /** Resolves the source file for the configured App component. */
 export function resolveAppComponentPath({ appPath, projectRoot }: AppComponentPathOptions): string {
-    return path.resolve(projectRoot, appPath)
+    return normalizePath(path.resolve(projectRoot, appPath))
 }
 
 /** Resolves the source file for one configured Page component. */
 export function resolvePageComponentPath({ pagePath, projectRoot }: PageComponentPathOptions): string {
-    return path.resolve(projectRoot, 'src', `${pagePath}.tsx`)
+    return normalizePath(path.resolve(projectRoot, 'src', `${pagePath}.tsx`))
 }
 
 /** Creates a portable import for one configured Page component. */


### PR DESCRIPTION
close https://github.com/sep2/vite-plugin-taro/issues/17

## Summary

- normalize configured App and Page paths before they enter the module graph so Windows uses one React Refresh family
- add a marker-free page self-update regression that verifies visible updates and retained React state
- make the DevTools HMR and published-package harnesses work with Windows paths, processes, and the current `wechatide` response shapes

## Root cause

The initial WX Page capsule resolved configured components with Windows backslashes, while incremental patches used Vite-normalized forward slashes. React Refresh treated those IDs as different families, so an isolated Page patch was acknowledged without updating the rendered Page.

## Validation

- `pnpm test` - 260 passed, 1 skipped
- `pnpm typecheck:plugin`
- `pnpm typecheck:loan-genius`
- `pnpm test:loan-genius:hmr` - all 26 flows passed in WeChat DevTools on Windows
- Biome checks and `git diff --check`