### PR TITLE
fix Windows WX HMR duplicate patches

### DIFF
--- a/packages/vite-plugin-taro/src/node/plugins/wx/dev/dev-host.integration.test.ts
+++ b/packages/vite-plugin-taro/src/node/plugins/wx/dev/dev-host.integration.test.ts
@@ -275,6 +275,29 @@ test('rejects startup with the original complete-output failure', async () => {
     }
 })
 
+test('coalesces one full-file save into one wx patch', async (context) => {
+    const fixture = await startDevFixture(createLogger('silent'), '127.0.0.1')
+    context.after(fixture.close)
+
+    await waitForFile(fixture.infoPath, (source) => source.includes('buildId'), maximumWaitAttempts)
+
+    await writeFile(fixture.pagePath, renderPage('one source generation'))
+    const publishedPatches = await waitForFile(
+        fixture.patchesPath,
+        (source) => source.includes('one source generation'),
+        maximumWaitAttempts
+    )
+    const stablePatches = await waitForStableFile(
+        fixture.patchesPath,
+        publishedPatches,
+        stableReadCount,
+        maximumWaitAttempts
+    )
+    const sequences = [...stablePatches.matchAll(/\{seq: (\d+)/g)].map((match) => Number(match[1]))
+
+    assert.deepEqual(sequences, [1])
+})
+
 test('publishes and acknowledges cumulative wx patches without rotating the App heap', async (context) => {
     const fixture = await startDevFixture(createLogger('silent'), '127.0.0.1')
     context.after(fixture.close)

--- a/packages/vite-plugin-taro/src/node/plugins/wx/dev/dev-host.test.ts
+++ b/packages/vite-plugin-taro/src/node/plugins/wx/dev/dev-host.test.ts
@@ -103,6 +103,8 @@ test('reduces synthetic engine update variants and unknown host failures without
     let triggerFullBuild: (() => void) | undefined
     const deliveredFiles: string[] = []
     const dev = (_input: unknown, _output: unknown, devOptions: DevOptions) => {
+        // Filesystem debounce normalizes duplicate native notifications before they become compiler generations.
+        assert.equal(devOptions.watch?.useDebounce, true)
         const onHmrUpdates = devOptions.onHmrUpdates
         const onOutput = devOptions.onOutput
         if (!onHmrUpdates || !onOutput) {

--- a/packages/vite-plugin-taro/src/node/plugins/wx/dev/dev-host.ts
+++ b/packages/vite-plugin-taro/src/node/plugins/wx/dev/dev-host.ts
@@ -268,11 +268,11 @@ export async function createWxDevHost({
             },
             rebuildStrategy: 'never',
             watch: {
-                // Rolldown must observe every source generation and emit every incremental factory: later patches do not
-                // reconstruct modules changed only by an earlier callback. RxJS conflates publication after compilation,
-                // preserving the complete patch sequence while avoiding repeated physical DevTools notifications.
+                // Normalize platform filesystem notifications before compilation. In particular, a single Windows full-file
+                // save can emit separate truncate and write events. Rolldown's debounce folds those physical events into one
+                // logical source generation; the RxJS result stream still preserves every callback emitted after compilation.
                 skipWrite: false,
-                useDebounce: false
+                useDebounce: true
             }
         })
     }


### PR DESCRIPTION
## Summary

- enable Rolldown filesystem-event debounce for WX development
- normalize Windows truncate/write notifications before compilation while preserving every post-compilation HMR callback
- add a cross-platform real-DevEngine regression test asserting one full-file save publishes exactly one patch

## Root cause

A Windows full-file save emits separate truncate and write notifications. The WX host explicitly disabled Rolldown's filesystem debounce, so both physical notifications became identical compiler generations and were retained in `hmr/patches.js`.

## Validation

- `pnpm typecheck:plugin`
- `pnpm build:plugin`
- `pnpm --filter vite-plugin-taro exec node --test --test-name-pattern="coalesces one full-file save" src/node/plugins/wx/dev/dev-host.integration.test.ts`
- verified the regression test fails with sequences `[1, 2]` when `useDebounce` is restored to `false`
